### PR TITLE
[Fix] broken curl service link on README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ flatpak run net.opentabletdriver.OpenTabletDriver -d
 If you want to start a driver at login, set up a user-level systemd service using the following steps:
 ```bash
 mkdir -p ~/.config/systemd/user/
-curl -s https://raw.githubusercontent.com/flathub/net.opentabletdriver.OpenTabletDriver/scripts/opentabletdriver.service > ~/.config/systemd/user/opentabletdriver.service
+curl -s https://raw.githubusercontent.com/flathub/net.opentabletdriver.OpenTabletDriver/refs/heads/master/scripts/opentabletdriver.service > ~/.config/systemd/user/opentabletdriver.service
 systemctl --user daemon-reload
 systemctl enable --now --user opentabletdriver.service
 ``` 


### PR DESCRIPTION
The section showing how to setup automatic startup using systemd has the curl command pointing to a 404 url, I updated the link so that the command works as expected