### PR TITLE
Clone `0.6.x` branch in udev script

### DIFF
--- a/docs/Manual-install.md
+++ b/docs/Manual-install.md
@@ -14,7 +14,7 @@ You are welcome to run these commands individually and inspect anything you like
 
 ```bash
 # Download the latest commit of OpenTabletDriver from the official github.
-git clone https://github.com/OpenTabletDriver/OpenTabletDriver.git --depth=1
+git clone https://github.com/OpenTabletDriver/OpenTabletDriver.git --branch 0.6.x --depth=1
 cd OpenTabletDriver
 # Run the udev generation script and write the output to /etc/udev/rules.d/
 ./generate-rules.sh | sudo tee /etc/udev/rules.d/70-opentabletdriver.rules

--- a/scripts/setup-udev.sh
+++ b/scripts/setup-udev.sh
@@ -55,7 +55,7 @@ check_udev_directory() {
             fi
         done
 
-        git clone https://github.com/OpenTabletDriver/OpenTabletDriver.git --depth=1
+        git clone https://github.com/OpenTabletDriver/OpenTabletDriver.git --branch 0.6.x --depth=1
         cd OpenTabletDriver
 
         ./generate-rules.sh | sudo tee /etc/udev/rules.d/70-opentabletdriver.rules

--- a/sources/linux-arm64.json
+++ b/sources/linux-arm64.json
@@ -134,10 +134,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm64/8.0.12/microsoft.aspnetcore.app.runtime.linux-arm64.8.0.12.nupkg",
-        "sha512": "0f01aadb6b38119a3d54cc929b4731009da4c870d0cc4874a343779bb1f2a0c7ddcb70714053a83ba44647c1d2be9981937b8f41b20e5fbdeebf818fd9084978",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm64/8.0.15/microsoft.aspnetcore.app.runtime.linux-arm64.8.0.15.nupkg",
+        "sha512": "3706b9215370e7d426c1880b774420452ec73dcba3447ef411508f635b800c4697707c395fcb9717fe9ec92ee2f8875ddfed93f488d4dd12fcdb750b2ac9be53",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-arm64.8.0.12.nupkg"
+        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-arm64.8.0.15.nupkg"
     },
     {
         "type": "file",
@@ -225,10 +225,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.net.illink.tasks/8.0.12/microsoft.net.illink.tasks.8.0.12.nupkg",
-        "sha512": "c7ce35e53b03172d6932de9cfcfbe33ba378d83c52f07e7733c75f5e0b40113897021640c76d26477e4cb21167fcb14fd5322093dd85dd7127e23ccdf1a9566d",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.net.illink.tasks/8.0.15/microsoft.net.illink.tasks.8.0.15.nupkg",
+        "sha512": "327325b2709e8485f8e821fa4429db3ec5f4e83577a17b4d533da10e6218cf3d8e71aee07fd4ed610e6dd7f69f39b7d2cbbb2eb6a82668e9919e0d11ef991105",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.net.illink.tasks.8.0.12.nupkg"
+        "dest-filename": "microsoft.net.illink.tasks.8.0.15.nupkg"
     },
     {
         "type": "file",
@@ -239,17 +239,17 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.linux-arm64/8.0.12/microsoft.netcore.app.host.linux-arm64.8.0.12.nupkg",
-        "sha512": "9896aaafc22a09189505fd49da2b2597c032ff8478dc5803c4f013e41fcd425fa19b6c61a79e6aca21522302d21c5edb99e0f29de1050c58be0734cd43a281d0",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.linux-arm64/8.0.15/microsoft.netcore.app.host.linux-arm64.8.0.15.nupkg",
+        "sha512": "0019b2be1591d38466c151d8f9bebd42f50425bb180748c7ac756624784760bf22489d4b4efdd0e379ca53ab7547e71e98e55fcb5ec2447bd5a4156ba9ee3f52",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.host.linux-arm64.8.0.12.nupkg"
+        "dest-filename": "microsoft.netcore.app.host.linux-arm64.8.0.15.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm64/8.0.12/microsoft.netcore.app.runtime.linux-arm64.8.0.12.nupkg",
-        "sha512": "f19d1425ed3bb3f7a83e39f247103c56c85603778a4de411738068b7065cb2055b9710893c91809931602ae12cdf1c13c5a9ee1893eaa764f41508924856f971",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm64/8.0.15/microsoft.netcore.app.runtime.linux-arm64.8.0.15.nupkg",
+        "sha512": "f2a65add8b98e54bb80fd72013331ecc27b02b4710936fb7fe3cd1a3e1fb19d5a7d37ef6e222910dc06f56b7f433cb6c96ee3415d9853d9a77c8e5b1df0440b2",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.runtime.linux-arm64.8.0.12.nupkg"
+        "dest-filename": "microsoft.netcore.app.runtime.linux-arm64.8.0.15.nupkg"
     },
     {
         "type": "file",

--- a/sources/linux-x64.json
+++ b/sources/linux-x64.json
@@ -134,10 +134,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/8.0.12/microsoft.aspnetcore.app.runtime.linux-x64.8.0.12.nupkg",
-        "sha512": "ebbcad53109c0f2682995908a372796c284528325fdc222324cb4127ed709da1aac9abe81ecf5cde419ea6956ef853b2c5b76e287342df923186d31faf70c430",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/8.0.15/microsoft.aspnetcore.app.runtime.linux-x64.8.0.15.nupkg",
+        "sha512": "ef8400d0e3bc796fd4c7e6aa32e9dafe95b6e08750d3e2356981ee162b86fe16ee253cd5ddbcd90a08f55f2fd125f59e5b333239913d46e0dd20e6a590ed21d6",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.8.0.12.nupkg"
+        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.8.0.15.nupkg"
     },
     {
         "type": "file",
@@ -225,10 +225,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.net.illink.tasks/8.0.12/microsoft.net.illink.tasks.8.0.12.nupkg",
-        "sha512": "c7ce35e53b03172d6932de9cfcfbe33ba378d83c52f07e7733c75f5e0b40113897021640c76d26477e4cb21167fcb14fd5322093dd85dd7127e23ccdf1a9566d",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.net.illink.tasks/8.0.15/microsoft.net.illink.tasks.8.0.15.nupkg",
+        "sha512": "327325b2709e8485f8e821fa4429db3ec5f4e83577a17b4d533da10e6218cf3d8e71aee07fd4ed610e6dd7f69f39b7d2cbbb2eb6a82668e9919e0d11ef991105",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.net.illink.tasks.8.0.12.nupkg"
+        "dest-filename": "microsoft.net.illink.tasks.8.0.15.nupkg"
     },
     {
         "type": "file",
@@ -239,10 +239,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/8.0.12/microsoft.netcore.app.runtime.linux-x64.8.0.12.nupkg",
-        "sha512": "8da9fabc64fbbe0f1f6ed3722679849378d83536d19f3c71d9bdfb44c6526ae6fde872e744045ef041edfa51668f2c63dfd0510bd8b3af15b518311479bcfaac",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/8.0.15/microsoft.netcore.app.runtime.linux-x64.8.0.15.nupkg",
+        "sha512": "401d52e6cec3a9a0257a4cd89920f1df1b35de316bdfcefc5be3d05b49ff81dbd47aabe33421a2002861a909c5eb80d3bda274c6414e22bedfd806e578355a02",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.8.0.12.nupkg"
+        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.8.0.15.nupkg"
     },
     {
         "type": "file",


### PR DESCRIPTION
`master` is not getting active contributions at this time, so cloning this branch for udev could result in outdated udev rules on OTD releases, targetting the active dev branch that this package is based on fixes that.