### PR TITLE
manifest: autoupdate for libnotify

### DIFF
--- a/net.opentabletdriver.OpenTabletDriver.yaml
+++ b/net.opentabletdriver.OpenTabletDriver.yaml
@@ -18,9 +18,13 @@ modules:
       - -Dman=false
       - -Dgtk_doc=false
     sources:
-      - type: git
-        url: https://gitlab.gnome.org/GNOME/libnotify.git
-        tag: 0.8.3
+      - type: archive
+        url: https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.7.tar.xz
+        sha256: 4be15202ec4184fce1ac15997ece5530d2be32fe9573875aeb10e3b573858748
+        x-checker-data:
+          type: gnome
+          name: libnotify
+          stable-only: true
 
   - name: libevdev
     buildsystem: meson

--- a/net.opentabletdriver.OpenTabletDriver.yaml
+++ b/net.opentabletdriver.OpenTabletDriver.yaml
@@ -17,6 +17,7 @@ modules:
     config-opts:
       - -Dman=false
       - -Dgtk_doc=false
+      - -Dtests=false
     sources:
       - type: archive
         url: https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.7.tar.xz


### PR DESCRIPTION
Updated libnotify source from git to archive format with new version and checksum.