### PR TITLE
Improve links and note additional install steps required in description

### DIFF
--- a/net.opentabletdriver.OpenTabletDriver.metainfo.xml
+++ b/net.opentabletdriver.OpenTabletDriver.metainfo.xml
@@ -36,7 +36,8 @@
   <url type="homepage">https://github.com/OpenTabletDriver/OpenTabletDriver</url>
   <url type="bugtracker">https://github.com/OpenTabletDriver/OpenTabletDriver/issues</url>
   <url type="faq">https://opentabletdriver.net/Wiki/FAQ/Linux</url>
-  <url type="help">https://opentabletdriver.net/Wiki/Install/Linux</url>
+  <url type="help">https://github.com/flathub/net.opentabletdriver.OpenTabletDriver/blob/master/README.md</url>
+  <url type="contact">https://opentabletdriver.net/Discord</url>
   <categories>
     <category>Settings</category>
   </categories>

--- a/net.opentabletdriver.OpenTabletDriver.metainfo.xml
+++ b/net.opentabletdriver.OpenTabletDriver.metainfo.xml
@@ -34,7 +34,8 @@
     <release version="v0.6.5.0" date="2024-12-18" type="stable"/>
     <release version="v0.6.4.0" date="2023-12-23" type="stable"/>
   </releases>
-  <url type="homepage">https://github.com/OpenTabletDriver/OpenTabletDriver</url>
+  <url type="homepage">https://www.opentabletdriver.net/</url>
+  <url type="vcs-browser">https://github.com/OpenTabletDriver/OpenTabletDriver</url>
   <url type="bugtracker">https://github.com/OpenTabletDriver/OpenTabletDriver/issues</url>
   <url type="faq">https://opentabletdriver.net/Wiki/FAQ/Linux</url>
   <url type="help">https://github.com/flathub/net.opentabletdriver.OpenTabletDriver/blob/master/README.md</url>

--- a/net.opentabletdriver.OpenTabletDriver.metainfo.xml
+++ b/net.opentabletdriver.OpenTabletDriver.metainfo.xml
@@ -12,6 +12,7 @@
   <project_group>OpenTabletDriver</project_group>
   <description>
     <p>OpenTabletDriver is an open source, cross platform, user mode tablet driver. The goal of OpenTabletDriver is to be cross platform as possible with the highest compatibility in an easily configurable graphical user interface.</p>
+    <p>**This package requires additional setup after installation.** Please check the help page for instructions.</p>
   </description>
   <screenshots>
     <screenshot type="default">


### PR DESCRIPTION
Users still have trouble figuring out where the instructions are or that there even are separate instructions for flatpak.

Also a bit of correction on the link types.