### PR TITLE
Drop libnotify module

### DIFF
--- a/net.opentabletdriver.OpenTabletDriver.yaml
+++ b/net.opentabletdriver.OpenTabletDriver.yaml
@@ -12,15 +12,6 @@ finish-args:
   - --share=network
   - --device=all
 modules:
-  - name: libnotify
-    buildsystem: meson
-    config-opts:
-      - -Dman=false
-      - -Dgtk_doc=false
-    sources:
-      - type: git
-        url: https://gitlab.gnome.org/GNOME/libnotify.git
-        tag: 0.8.3
 
   - name: libevdev
     buildsystem: meson


### PR DESCRIPTION
Drop the libnotify module, which is already provided by the runtime.

Fixes: https://github.com/flathub/net.opentabletdriver.OpenTabletDriver/issues/48